### PR TITLE
Truncate lines longer than the width of the window

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.14
 require (
 	github.com/charmbracelet/bubbles v0.7.2
 	github.com/charmbracelet/bubbletea v0.12.1
+	github.com/muesli/reflow v0.2.1-0.20201126184510-3bcb929042f2
 	github.com/muesli/termenv v0.7.4
 )

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/muesli/reflow v0.2.1-0.20201126184510-3bcb929042f2 h1:+cpkcmASpeBn4qXz2tU+x+njyKe91NoHXqrJdhoDnZo=
+github.com/muesli/reflow v0.2.1-0.20201126184510-3bcb929042f2/go.mod h1:qT22vjVmM9MIUeLgsVYe/Ye7eZlbv9dZjL3dVhUqLX8=
 github.com/muesli/termenv v0.7.2/go.mod h1:ct2L5N2lmix82RaY3bMWwVu/jUFc9Ule0KGDCiKYPh8=
 github.com/muesli/termenv v0.7.4 h1:/pBqvU5CpkY53tU0vVn+xgs2ZTX63aH5nY+SSps5Xa8=
 github.com/muesli/termenv v0.7.4/go.mod h1:pZ7qY9l3F7e5xsAOS0zCew2tME+p7bWeBkotCEcIIcc=


### PR DESCRIPTION
This is a small update to trim long lines that would otherwise wrap. I figure it's important to know which modules are indirect, so I made a point to keep that portion while trimming the rest of the line. I also dimmed the `// indirect` portion slightly for aesthetic purposes.

Happy to adjust, and feel free to make edits to this PR, too.

<img width="773" alt="modu" src="https://user-images.githubusercontent.com/25087/104509121-387ca100-55b7-11eb-86b2-c988e3f391cb.png">

Very nice work on this tool, by the way (I'm the Bubble Tea author).